### PR TITLE
Possibility to exclude players from physicworld

### DIFF
--- a/src/main/java/fr/dynamx/api/physics/player/DynamXPhysicsWorldBlacklistApi.java
+++ b/src/main/java/fr/dynamx/api/physics/player/DynamXPhysicsWorldBlacklistApi.java
@@ -1,0 +1,18 @@
+package fr.dynamx.api.physics.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+
+public class DynamXPhysicsWorldBlacklistApi {
+
+    private static IPhysicsWorldBlacklist blackListCondition;
+
+    public static void setPhysicsWorldBlackListCondition(IPhysicsWorldBlacklist blackList) {
+        DynamXPhysicsWorldBlacklistApi.blackListCondition = blackList;
+    }
+
+    public static boolean isBlacklisted(EntityPlayer player) {
+        if(DynamXPhysicsWorldBlacklistApi.blackListCondition == null) return false;
+        return DynamXPhysicsWorldBlacklistApi.blackListCondition.isBlacklisted(player);
+    }
+
+}

--- a/src/main/java/fr/dynamx/api/physics/player/DynamXPhysicsWorldBlacklistApi.java
+++ b/src/main/java/fr/dynamx/api/physics/player/DynamXPhysicsWorldBlacklistApi.java
@@ -2,16 +2,37 @@ package fr.dynamx.api.physics.player;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+/**
+ * An api class to exclude players from physics world
+ *
+ * @see IPhysicsWorldBlacklist
+ */
 public class DynamXPhysicsWorldBlacklistApi {
 
-    private static IPhysicsWorldBlacklist blackListCondition;
+    /**
+     * Condition
+     */
+    private static IPhysicsWorldBlacklist blackListCondition = player -> false;
 
+    /**
+     * @param blackList - Blacklist that will be applied to DynamX
+     */
     public static void setPhysicsWorldBlackListCondition(IPhysicsWorldBlacklist blackList) {
         DynamXPhysicsWorldBlacklistApi.blackListCondition = blackList;
     }
 
+    /**
+     * @return - Active PhysicsWorldBlacklist Condition
+     */
+    public static IPhysicsWorldBlacklist getActiveCondition() {
+       return DynamXPhysicsWorldBlacklistApi.blackListCondition;
+    }
+
+    /**
+     * @param player - The player that will be added in PhysicsWorld
+     * @return - Player is blacklisted from world
+     */
     public static boolean isBlacklisted(EntityPlayer player) {
-        if(DynamXPhysicsWorldBlacklistApi.blackListCondition == null) return false;
         return DynamXPhysicsWorldBlacklistApi.blackListCondition.isBlacklisted(player);
     }
 

--- a/src/main/java/fr/dynamx/api/physics/player/IPhysicsWorldBlacklist.java
+++ b/src/main/java/fr/dynamx/api/physics/player/IPhysicsWorldBlacklist.java
@@ -2,8 +2,15 @@ package fr.dynamx.api.physics.player;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+/**
+ * Interface for PhysicsWorld Blacklist
+ */
 public interface IPhysicsWorldBlacklist {
 
+    /**
+     * @param player - The Player that will be added in Physics World
+     * @return isBlacklisted from PhysicsWorld
+     */
     boolean isBlacklisted(EntityPlayer player);
 
 }

--- a/src/main/java/fr/dynamx/api/physics/player/IPhysicsWorldBlacklist.java
+++ b/src/main/java/fr/dynamx/api/physics/player/IPhysicsWorldBlacklist.java
@@ -1,0 +1,9 @@
+package fr.dynamx.api.physics.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+
+public interface IPhysicsWorldBlacklist {
+
+    boolean isBlacklisted(EntityPlayer player);
+
+}

--- a/src/main/java/fr/dynamx/common/handlers/CommonEventHandler.java
+++ b/src/main/java/fr/dynamx/common/handlers/CommonEventHandler.java
@@ -6,6 +6,7 @@ import fr.dynamx.api.contentpack.object.render.IResourcesOwner;
 import fr.dynamx.api.entities.IModuleContainer;
 import fr.dynamx.api.events.VehicleEntityEvent;
 import fr.dynamx.api.network.EnumPacketTarget;
+import fr.dynamx.api.physics.player.DynamXPhysicsWorldBlacklistApi;
 import fr.dynamx.common.DynamXContext;
 import fr.dynamx.common.DynamXMain;
 import fr.dynamx.common.blocks.DynamXBlock;
@@ -275,9 +276,12 @@ public class CommonEventHandler {
 
     //Walking players :
 
+
+
     @SubscribeEvent
     public void onPlayerUpdate(TickEvent.PlayerTickEvent e) {
         if (!(e.player.getRidingEntity() instanceof BaseVehicleEntity) && DynamXContext.getPhysicsWorld() != null && !e.player.isDead) {
+            if(!DynamXContext.getPlayerToCollision().containsKey(e.player) && DynamXPhysicsWorldBlacklistApi.isBlacklisted(e.player)) return;
             Vector3fPool.openPool();
             QuaternionPool.openPool();
             if (!DynamXContext.getPlayerToCollision().containsKey(e.player)) {

--- a/src/main/java/fr/dynamx/common/handlers/CommonEventHandler.java
+++ b/src/main/java/fr/dynamx/common/handlers/CommonEventHandler.java
@@ -277,7 +277,6 @@ public class CommonEventHandler {
     //Walking players :
 
 
-
     @SubscribeEvent
     public void onPlayerUpdate(TickEvent.PlayerTickEvent e) {
         if (!(e.player.getRidingEntity() instanceof BaseVehicleEntity) && DynamXContext.getPhysicsWorld() != null && !e.player.isDead) {


### PR DESCRIPTION
Offers the possibility to exclude players from the physic. In my case, for example, not to take over NPC's into the physic world. Because they become more and more and increase the bullet physic calculation.