### PR TITLE
fix building and finding sponge refmap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,7 @@ mixin {
 }
 
 jar {
+    duplicatesStrategy 'exclude'
     manifest {
         attributes "FMLCorePlugin": "fr.dynamx.common.core.DynamXCoreMod"
         attributes "FMLAT": "dynamx_at.cfg"
@@ -106,6 +107,7 @@ jar {
 }
 
 shadowJar {
+    duplicatesStrategy 'exclude'
     configurations = [project.configurations.shadow]
     classifier = 'all'
 }

--- a/src/main/resources/mixins.dynamxmod.json
+++ b/src/main/resources/mixins.dynamxmod.json
@@ -1,6 +1,7 @@
 {
   "compatibilityLevel": "JAVA_8",
   "package": "fr.dynamx.common.core.mixin",
+  "refmap": "refmap.dynamxmod.json",
   "mixins": [
     "MixinEntity",
     "MixinEntityLivingBase",


### PR DESCRIPTION
On the newest commit in the beta branche building is broken because there are duplicated entries, i put a duplicatesStrategy in jar & shadowJar to avoid this problem. Otherwise DynamX cannot apply mixin stuff because the refmap is not marked in the mixin config