### PR TITLE
unnecessary contains calls removed

### DIFF
--- a/src/main/java/fr/dynamx/common/physics/utils/PhysicsWorldOperation.java
+++ b/src/main/java/fr/dynamx/common/physics/utils/PhysicsWorldOperation.java
@@ -3,15 +3,12 @@ package fr.dynamx.common.physics.utils;
 import com.jme3.bullet.PhysicsSpace;
 import com.jme3.bullet.collision.PhysicsCollisionObject;
 import com.jme3.bullet.joints.PhysicsJoint;
-import com.jme3.bullet.objects.PhysicsRigidBody;
 import fr.dynamx.common.DynamXMain;
 import fr.dynamx.common.entities.PhysicsEntity;
 
 import javax.annotation.Nullable;
-import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
@@ -58,17 +55,13 @@ public class PhysicsWorldOperation<A> {
                     if (dynamicsWorld.getVehicleList().contains(object))
                         DynamXMain.log.fatal("PhysicsVehicle " + object + " is already in the physics world, please report this !");
                 case ADD_OBJECT:
-                    if (!dynamicsWorld.contains((PhysicsCollisionObject) object))
-                        dynamicsWorld.addCollisionObject((PhysicsCollisionObject) object);
-                    else
-                        DynamXMain.log.fatal("PhysicsCollisionObject " + object + " is already registered, please report this !");
+                    dynamicsWorld.addCollisionObject((PhysicsCollisionObject) object);
                     break;
                 case REMOVE_VEHICLE:
                     if (!dynamicsWorld.getVehicleList().contains(object))
                         DynamXMain.log.fatal("PhysicsVehicle " + object + " is not is the physics world, please report this !");
                 case REMOVE_OBJECT:
-                    if (dynamicsWorld.contains((PhysicsCollisionObject) object))
-                        dynamicsWorld.removeCollisionObject((PhysicsCollisionObject) object);
+                    dynamicsWorld.removeCollisionObject((PhysicsCollisionObject) object);
                     break;
                 case ADD_ENTITY:
                     if (entities.contains(object))

--- a/src/main/java/fr/dynamx/common/physics/utils/PhysicsWorldOperation.java
+++ b/src/main/java/fr/dynamx/common/physics/utils/PhysicsWorldOperation.java
@@ -52,14 +52,10 @@ public class PhysicsWorldOperation<A> {
         if (object != null) {
             switch (operation) {
                 case ADD_VEHICLE:
-                    if (dynamicsWorld.getVehicleList().contains(object))
-                        DynamXMain.log.fatal("PhysicsVehicle " + object + " is already in the physics world, please report this !");
                 case ADD_OBJECT:
                     dynamicsWorld.addCollisionObject((PhysicsCollisionObject) object);
                     break;
                 case REMOVE_VEHICLE:
-                    if (!dynamicsWorld.getVehicleList().contains(object))
-                        DynamXMain.log.fatal("PhysicsVehicle " + object + " is not is the physics world, please report this !");
                 case REMOVE_OBJECT:
                     dynamicsWorld.removeCollisionObject((PhysicsCollisionObject) object);
                     break;


### PR DESCRIPTION
the contains queries are already done in the bulletlib in "addCollisionObject" and "removeCollisionObject".
removing these duplicate checks will again have an impact on performance improvement