### PR TITLE
fix: prevent NullPointerException in MaterialTexture.uploadTexture

### DIFF
--- a/src/main/java/fr/dynamx/client/renders/model/texture/MaterialTexture.java
+++ b/src/main/java/fr/dynamx/client/renders/model/texture/MaterialTexture.java
@@ -1,6 +1,7 @@
 package fr.dynamx.client.renders.model.texture;
 
 import fr.aym.acslib.impl.services.thrload.ThreadedTexture;
+import fr.dynamx.common.DynamXMain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -39,7 +40,7 @@ public class MaterialTexture {
                 glTextureId = obj.getGlTextureId();
             }
         } else {
-            System.out.println("Texture could not be uploaded because it is null");
+            DynamXMain.log.warn("Texture could not be uploaded because it is null");
         }
     }
 }

--- a/src/main/java/fr/dynamx/client/renders/model/texture/MaterialTexture.java
+++ b/src/main/java/fr/dynamx/client/renders/model/texture/MaterialTexture.java
@@ -29,10 +29,17 @@ public class MaterialTexture {
 
     public void uploadTexture(TextureManager man) {
         ITextureObject obj = man.getTexture(path);
-        if(obj == null) //happens sometimes o_o
+        if (obj == null) { // happens sometimes o_0
             loadTexture(man);
-        if (obj instanceof ThreadedTexture)
-            ((ThreadedTexture) obj).uploadTexture(man);
-        glTextureId = obj.getGlTextureId();
+            obj = man.getTexture(path);
+        }
+        if (obj != null) {
+            if (obj instanceof ThreadedTexture) {
+                ((ThreadedTexture) obj).uploadTexture(man);
+                glTextureId = obj.getGlTextureId();
+            }
+        } else {
+            System.out.println("Texture could not be uploaded because it is null");
+        }
     }
 }


### PR DESCRIPTION
The uploadTexture() method has been updated to prevent a possible NullPointerException. In the original code, the object was still null and could throw a NullPointerException on "obj.getGlTextureId()"