### PR TITLE
PhysicsCollisionEvent: add pre event

### DIFF
--- a/src/main/java/fr/dynamx/api/events/PhysicsEvent.java
+++ b/src/main/java/fr/dynamx/api/events/PhysicsEvent.java
@@ -1,5 +1,6 @@
 package fr.dynamx.api.events;
 
+import com.jme3.bullet.collision.PhysicsCollisionEvent;
 import fr.dynamx.api.physics.BulletShapeType;
 import fr.dynamx.api.physics.IPhysicsWorld;
 import fr.dynamx.common.entities.PhysicsEntity;
@@ -99,5 +100,22 @@ public class PhysicsEvent extends Event {
             this.object2 = object2;
             this.collisionInfo = collisionInfo;
         }
+
+
+        public static class Pre extends PhysicsEvent {
+
+            @Getter
+            private final PhysicsCollisionEvent physicsEvent;
+
+            /**
+             * @param world   The physics world owning this chunk
+             * @param event Physics Collision Event provided from jme bullet lib
+             */
+            public Pre(IPhysicsWorld world, PhysicsCollisionEvent event) {
+                super(world);
+                this.physicsEvent = event;
+            }
+        }
+
     }
 }

--- a/src/main/java/fr/dynamx/api/events/PhysicsEvent.java
+++ b/src/main/java/fr/dynamx/api/events/PhysicsEvent.java
@@ -102,18 +102,15 @@ public class PhysicsEvent extends Event {
         }
 
 
-        public static class Pre extends PhysicsEvent {
-
-            @Getter
-            private final PhysicsCollisionEvent physicsEvent;
+        public static class Pre extends PhysicsCollision {
 
             /**
              * @param world   The physics world owning this chunk
-             * @param event Physics Collision Event provided from jme bullet lib
+             * @param object1 First collision object colliding with the second
+             * @param object2 Second collision object colliding with the first
              */
-            public Pre(IPhysicsWorld world, PhysicsCollisionEvent event) {
-                super(world);
-                this.physicsEvent = event;
+            public Pre(IPhysicsWorld world, BulletShapeType<?> object1, BulletShapeType<?> object2, CollisionsHandler.CollisionInfo collisionInfo) {
+                super(world, object1, object2, collisionInfo);
             }
         }
 

--- a/src/main/java/fr/dynamx/common/physics/CollisionsHandler.java
+++ b/src/main/java/fr/dynamx/common/physics/CollisionsHandler.java
@@ -29,8 +29,8 @@ public class CollisionsHandler {
     /**
      * Handles collision between two bodies <br>
      */
-    public static void handleCollision(IPhysicsWorld physicsWorld, PhysicsCollisionEvent collisionEvent, BulletShapeType<?> bodyA, BulletShapeType<?> bodyB) {
-        if (bodyA.getType().isEntity() && bodyB.getType().isEntity() || bodyA.getType().isEntity() && bodyB.getType().isTerrain() || bodyA.getType().isTerrain() && bodyB.getType().isEntity()) {
+    public static void handleCollision(IPhysicsWorld physicsWorld, PhysicsCollisionEvent collisionEvent, BulletShapeType<?> bodyA, BulletShapeType<?> bodyB, float impulse) {
+        if ((bodyA.getType().isEntity() && bodyB.getType().isEntity()) || (bodyA.getType().isEntity() && bodyB.getType().isTerrain()) || (bodyA.getType().isTerrain() && bodyB.getType().isEntity())) {
             CollisionInfo info = new CollisionInfo(physicsWorld, bodyA, bodyB, EXPIRATION_TIME, collisionEvent);
             if (CACHED_COLLISIONS.add(info)) {
                 info.handleCollision();

--- a/src/main/java/fr/dynamx/common/physics/CollisionsHandler.java
+++ b/src/main/java/fr/dynamx/common/physics/CollisionsHandler.java
@@ -29,7 +29,7 @@ public class CollisionsHandler {
     /**
      * Handles collision between two bodies <br>
      */
-    public static void handleCollision(IPhysicsWorld physicsWorld, PhysicsCollisionEvent collisionEvent, BulletShapeType<?> bodyA, BulletShapeType<?> bodyB, float impulse) {
+    public static void handleCollision(IPhysicsWorld physicsWorld, PhysicsCollisionEvent collisionEvent, BulletShapeType<?> bodyA, BulletShapeType<?> bodyB) {
         if ((bodyA.getType().isEntity() && bodyB.getType().isEntity()) || (bodyA.getType().isEntity() && bodyB.getType().isTerrain()) || (bodyA.getType().isTerrain() && bodyB.getType().isEntity())) {
             CollisionInfo info = new CollisionInfo(physicsWorld, bodyA, bodyB, EXPIRATION_TIME, collisionEvent);
             if (CACHED_COLLISIONS.add(info)) {

--- a/src/main/java/fr/dynamx/common/physics/CollisionsHandler.java
+++ b/src/main/java/fr/dynamx/common/physics/CollisionsHandler.java
@@ -30,6 +30,7 @@ public class CollisionsHandler {
      * Handles collision between two bodies <br>
      */
     public static void handleCollision(IPhysicsWorld physicsWorld, PhysicsCollisionEvent collisionEvent, BulletShapeType<?> bodyA, BulletShapeType<?> bodyB) {
+        MinecraftForge.EVENT_BUS.post(new PhysicsEvent.PhysicsCollision.Pre(physicsWorld, bodyA, bodyB, new CollisionInfo(physicsWorld, bodyA, bodyB, EXPIRATION_TIME, collisionEvent)));
         if ((bodyA.getType().isEntity() && bodyB.getType().isEntity()) || (bodyA.getType().isEntity() && bodyB.getType().isTerrain()) || (bodyA.getType().isTerrain() && bodyB.getType().isEntity())) {
             CollisionInfo info = new CollisionInfo(physicsWorld, bodyA, bodyB, EXPIRATION_TIME, collisionEvent);
             if (CACHED_COLLISIONS.add(info)) {

--- a/src/main/java/fr/dynamx/common/physics/CollisionsHandler.java
+++ b/src/main/java/fr/dynamx/common/physics/CollisionsHandler.java
@@ -30,9 +30,9 @@ public class CollisionsHandler {
      * Handles collision between two bodies <br>
      */
     public static void handleCollision(IPhysicsWorld physicsWorld, PhysicsCollisionEvent collisionEvent, BulletShapeType<?> bodyA, BulletShapeType<?> bodyB) {
-        MinecraftForge.EVENT_BUS.post(new PhysicsEvent.PhysicsCollision.Pre(physicsWorld, bodyA, bodyB, new CollisionInfo(physicsWorld, bodyA, bodyB, EXPIRATION_TIME, collisionEvent)));
         if ((bodyA.getType().isEntity() && bodyB.getType().isEntity()) || (bodyA.getType().isEntity() && bodyB.getType().isTerrain()) || (bodyA.getType().isTerrain() && bodyB.getType().isEntity())) {
             CollisionInfo info = new CollisionInfo(physicsWorld, bodyA, bodyB, EXPIRATION_TIME, collisionEvent);
+            MinecraftForge.EVENT_BUS.post(new PhysicsEvent.PhysicsCollision.Pre(physicsWorld, bodyA, bodyB, info));
             if (CACHED_COLLISIONS.add(info)) {
                 info.handleCollision();
             }

--- a/src/main/java/fr/dynamx/common/physics/world/BasePhysicsWorld.java
+++ b/src/main/java/fr/dynamx/common/physics/world/BasePhysicsWorld.java
@@ -81,7 +81,7 @@ public abstract class BasePhysicsWorld implements IPhysicsWorld {
                 PhysicsCollisionEvent event = new PhysicsCollisionEvent(pcoA, pcoB, contactPointId);
                 float impulse = event.getAppliedImpulse();
                 MinecraftForge.EVENT_BUS.post(new PhysicsEvent.PhysicsCollision.Pre(physicsWorld, event));
-                CollisionsHandler.handleCollision(physicsWorld, event, (BulletShapeType<?>) pcoA.getUserObject(), (BulletShapeType<?>) pcoB.getUserObject(), impulse);
+                CollisionsHandler.handleCollision(physicsWorld, event, (BulletShapeType<?>) pcoA.getUserObject(), (BulletShapeType<?>) pcoB.getUserObject());
             }
 
             @Override

--- a/src/main/java/fr/dynamx/common/physics/world/BasePhysicsWorld.java
+++ b/src/main/java/fr/dynamx/common/physics/world/BasePhysicsWorld.java
@@ -78,7 +78,10 @@ public abstract class BasePhysicsWorld implements IPhysicsWorld {
             @Override
             public void onContactProcessed(PhysicsCollisionObject pcoA, PhysicsCollisionObject pcoB, long contactPointId) {
                 // memory leak fix : don't call super method : bullets stores all collision events in a queue
-                CollisionsHandler.handleCollision(physicsWorld, new PhysicsCollisionEvent(pcoA, pcoB, contactPointId), (BulletShapeType<?>) pcoA.getUserObject(), (BulletShapeType<?>) pcoB.getUserObject());
+                PhysicsCollisionEvent event = new PhysicsCollisionEvent(pcoA, pcoB, contactPointId);
+                float impulse = event.getAppliedImpulse();
+                MinecraftForge.EVENT_BUS.post(new PhysicsEvent.PhysicsCollision.Pre(physicsWorld, event));
+                CollisionsHandler.handleCollision(physicsWorld, event, (BulletShapeType<?>) pcoA.getUserObject(), (BulletShapeType<?>) pcoB.getUserObject(), impulse);
             }
 
             @Override

--- a/src/main/java/fr/dynamx/common/physics/world/BasePhysicsWorld.java
+++ b/src/main/java/fr/dynamx/common/physics/world/BasePhysicsWorld.java
@@ -78,10 +78,7 @@ public abstract class BasePhysicsWorld implements IPhysicsWorld {
             @Override
             public void onContactProcessed(PhysicsCollisionObject pcoA, PhysicsCollisionObject pcoB, long contactPointId) {
                 // memory leak fix : don't call super method : bullets stores all collision events in a queue
-                PhysicsCollisionEvent event = new PhysicsCollisionEvent(pcoA, pcoB, contactPointId);
-                float impulse = event.getAppliedImpulse();
-                MinecraftForge.EVENT_BUS.post(new PhysicsEvent.PhysicsCollision.Pre(physicsWorld, event));
-                CollisionsHandler.handleCollision(physicsWorld, event, (BulletShapeType<?>) pcoA.getUserObject(), (BulletShapeType<?>) pcoB.getUserObject());
+                CollisionsHandler.handleCollision(physicsWorld, new PhysicsCollisionEvent(pcoA, pcoB, contactPointId), (BulletShapeType<?>) pcoA.getUserObject(), (BulletShapeType<?>) pcoB.getUserObject());
             }
 
             @Override


### PR DESCRIPTION
Hey, it's me again, I had a little problem with DynamX which i wanted to "fix" with this commit. I tried to add custom vehicle detection with a own mod and in my first implementation. I used the PhysicsSoftSpace#addCollisionListener function which is now deprecated and I seen a while ago DynamX added a event PhysicsCollisions  which was my time to shine to readd this feature. Now I have the problem that this forge event is not firing every collision, it fires the collision of 2 same entities every (3?) seconds. It's quite a problem because the first collision have a applied impulse (PhysicsCollisionEvent#getAppliedImpulse) of 0. Of course I need the right value of the impulse to provide this feature.

When there is a better solution for this I would really happy when you guys tell me of it but it's always complicated to become a clearly view of code which is not mine :)

ps: With the pre event I get the right impulse value, for your informations but I can imagine this is not the best solution for my problem 