### PR TITLE
add: option to not use render distance of vehicle/prop config

### DIFF
--- a/src/main/java/fr/dynamx/common/entities/PackPhysicsEntity.java
+++ b/src/main/java/fr/dynamx/common/entities/PackPhysicsEntity.java
@@ -16,6 +16,7 @@ import fr.dynamx.common.contentpack.parts.BasePartSeat;
 import fr.dynamx.common.entities.modules.MovableModule;
 import fr.dynamx.common.physics.entities.PackEntityPhysicsHandler;
 import fr.dynamx.common.physics.joints.EntityJointsHandler;
+import fr.dynamx.utils.DynamXConfig;
 import fr.dynamx.utils.client.ClientDynamXUtils;
 import fr.dynamx.utils.maths.DynamXGeometry;
 import fr.dynamx.utils.optimization.MutableBoundingBox;
@@ -151,6 +152,7 @@ public abstract class PackPhysicsEntity<T extends PackEntityPhysicsHandler<A, ?>
 
     @Override
     public boolean isInRangeToRenderDist(double range) {
+        if(!DynamXConfig.usePackRenderDistances) return super.isInRangeToRenderDist(range);
         return getPackInfo() != null && getPackInfo().getRenderDistance() >= range;
     }
 

--- a/src/main/java/fr/dynamx/utils/DynamXConfig.java
+++ b/src/main/java/fr/dynamx/utils/DynamXConfig.java
@@ -39,6 +39,8 @@ public class DynamXConfig
 
     public static boolean disableSSLCertification;
 
+    public static boolean usePackRenderDistances;
+
     @Getter
     private static float masterSoundVolume = 0.8f;
     @Getter
@@ -91,6 +93,7 @@ public class DynamXConfig
 
         masterSoundVolume = (float) cfg.get("Sounds", "Volume", 0.8f, "The volume of DynamX sounds (engines...)").getDouble();
         maxSounds = cfg.get("Sounds", "MaxSounds", 8, "The maximum amount of sounds DynamX can play at the same time").getInt();
+        usePackRenderDistances = cfg.get("Multiplayer", "UsePackRenderDistances", true, "Use Pack Render Distances from the vehicle/prop config").getBoolean();
         cfg.save();
     }
 


### PR DESCRIPTION
Since the commit where Ayermic was adding the functionality to config the render distance of vehicle/props players cannot see vehicles from far away up (with default configuration too), which is very unlikely for the players when they are in helicopters. The default value of the configuration is true that nothing will be changed in default but when a player turn it off dynamx will use the remain solution for it 