### PR TITLE
player collision will be handled not so often like before

### DIFF
--- a/src/main/java/fr/dynamx/api/physics/IRotatedCollisionHandler.java
+++ b/src/main/java/fr/dynamx/api/physics/IRotatedCollisionHandler.java
@@ -4,6 +4,7 @@ import com.jme3.math.Quaternion;
 import com.jme3.math.Vector3f;
 import fr.dynamx.utils.optimization.MutableBoundingBox;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.MoverType;
 import net.minecraft.util.math.AxisAlignedBB;
 
 /**
@@ -41,7 +42,7 @@ public interface IRotatedCollisionHandler {
     /**
      * @return the updated motion of entity after colliding it with physics entities
      */
-    double[] handleCollisionWithBulletEntities(Entity entity, double mx, double my, double mz);
+    double[] handleCollisionWithBulletEntities(Entity entity, MoverType moverType, double mx, double my, double mz);
 
     /**
      * @return True if the last call to handleCollisionWithBulletEntities has changed the entity motion

--- a/src/main/java/fr/dynamx/common/core/mixin/MixinEntity.java
+++ b/src/main/java/fr/dynamx/common/core/mixin/MixinEntity.java
@@ -53,7 +53,7 @@ public abstract class MixinEntity {
         AxisAlignedBB axisalignedbb = getEntityBoundingBox();
         Vector3fPool.openPool();
         Profiler.get().start(Profiler.Profiles.ENTITY_COLLISION);
-        double[] data = DynamXContext.getCollisionHandler().handleCollisionWithBulletEntities((Entity) (Object) this, x, y, z);
+        double[] data = DynamXContext.getCollisionHandler().handleCollisionWithBulletEntities((Entity) (Object) this, type, x, y, z);
         Profiler.get().end(Profiler.Profiles.ENTITY_COLLISION);
         Vector3fPool.closePool();
         x1 = data[0];

--- a/src/main/java/fr/dynamx/common/handlers/RotatedCollisionHandlerImpl.java
+++ b/src/main/java/fr/dynamx/common/handlers/RotatedCollisionHandlerImpl.java
@@ -16,6 +16,7 @@ import fr.dynamx.utils.maths.DynamXGeometry;
 import fr.dynamx.utils.maths.DynamXMath;
 import fr.dynamx.utils.optimization.*;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.MoverType;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -334,8 +335,15 @@ public class RotatedCollisionHandlerImpl implements IRotatedCollisionHandler {
         return motionChanged;
     }
 
+    private boolean shouldHandleCollision(Entity entity, MoverType moverType) {
+        if(entity instanceof EntityPlayer) {
+            return moverType.equals(MoverType.PLAYER);
+        }
+        return (!(entity instanceof PhysicsEntity));
+    }
+
     @Override
-    public double[] handleCollisionWithBulletEntities(Entity entity, double mx, double my, double mz) {
+    public double[] handleCollisionWithBulletEntities(Entity entity, MoverType moverType, double mx, double my, double mz) {
         double icollidableCheckRadius = DynamXConfig.blockCollisionRadius;
         AxisAlignedBB copy = entity.getEntityBoundingBox().grow(0);
 
@@ -369,7 +377,8 @@ public class RotatedCollisionHandlerImpl implements IRotatedCollisionHandler {
         }
 
         motionChanged = false;
-        if (!(entity instanceof PhysicsEntity)) {
+
+        if(shouldHandleCollision(entity, moverType)) {
             PooledHashMap<Vector3f, IDynamXObject> collidableEntities = getCollidableTileEntities(entity.world, new MutableBoundingBox(entity.getEntityBoundingBox()).grow(icollidableCheckRadius));
             for (Map.Entry<Vector3f, IDynamXObject> e : collidableEntities.entrySet()) {
                 //System.out.println("Input "+mx+" "+my+" "+mz+" "+nx+" "+ny+" "+nz+" "+entity.onGround+" "+entity.collidedVertically+" "+e.physicsPosition);


### PR DESCRIPTION
hello, one day we figured out that our server produce lags, specially the function RotatedCollisionHandlerImpl#getCollidableTileEntities, when the server hits 40-50+ players. We searched for a long time for a solution, but we haven't found a good fix to improve performance directly on the function. 

The other day we found out that players call this function even if they didn't move. That's very bad and we found out that we can differentiate between move from the player itself and (player tick?).

That's exactly that what I was adding in this pull request and it fixed now the lags.
It would be very nice when we found a better solution for the function itself but it is what it is.

ps: it not breaks something about the collisions to vehicles/dynamx blocks/props, we tested it on our environment :)