### PR TITLE
Fix/block seat rotation

### DIFF
--- a/src/main/java/fr/dynamx/common/contentpack/parts/BasePartSeat.java
+++ b/src/main/java/fr/dynamx/common/contentpack/parts/BasePartSeat.java
@@ -35,17 +35,17 @@ public abstract class BasePartSeat<A extends IDynamXObject, T extends ISubInfoTy
     @PackFileProperty(configNames = "ShouldLimitFieldOfView", required = false, defaultValue = "true")
     protected boolean shouldLimitFieldOfView = true;
 
-    @PackFileProperty(configNames = "MaxYaw", required = false, defaultValue = "-105")
-    protected float maxYaw = -105.0f;
+    @PackFileProperty(configNames = "MaxYaw", required = false, defaultValue = "105")
+    protected float maxYaw = 105.0f;
 
-    @PackFileProperty(configNames = "MinYaw", required = false, defaultValue = "105")
-    protected float minYaw = 105.0f;
+    @PackFileProperty(configNames = "MinYaw", required = false, defaultValue = "-105")
+    protected float minYaw = -105.0f;
 
-    @PackFileProperty(configNames = "MaxPitch", required = false, defaultValue = "-105")
-    protected float maxPitch = -105.0f;
+    @PackFileProperty(configNames = "MaxPitch", required = false, defaultValue = "105")
+    protected float maxPitch = 105.0f;
 
-    @PackFileProperty(configNames = "MinPitch", required = false, defaultValue = "105")
-    protected float minPitch = 105.0f;
+    @PackFileProperty(configNames = "MinPitch", required = false, defaultValue = "-105")
+    protected float minPitch = -105.0f;
 
     @PackFileProperty(configNames = "Rotation", required = false, defaultValue = "1 0 0 0")
     protected Quaternion rotation;

--- a/src/main/java/fr/dynamx/common/entities/SeatEntity.java
+++ b/src/main/java/fr/dynamx/common/entities/SeatEntity.java
@@ -49,18 +49,20 @@ public class SeatEntity extends Entity {
     @Override
     public void applyOrientationToEntity(Entity passenger) {
         if (mySeat != null && mySeat.shouldLimitFieldOfView()) {
+            float blockYaw = block.getPackInfo() == null ? 0 : (block.getPackInfo().getRotation().y - block.getRelativeRotation().y + block.getRotation() * 22.5f);
+
             float f = MathHelper.wrapDegrees(passenger.rotationYaw);
-            float f1 = MathHelper.clamp(f, mySeat.getMaxYaw(), mySeat.getMinYaw());
+            float f1 = MathHelper.clamp(f, MathHelper.wrapDegrees(mySeat.getMinYaw() + blockYaw), MathHelper.wrapDegrees(mySeat.getMaxYaw() + blockYaw));
             passenger.rotationYaw = f1;
             f = MathHelper.wrapDegrees(passenger.prevRotationYaw);
-            f1 = MathHelper.clamp(f, mySeat.getMaxYaw(), mySeat.getMinYaw());
+            f1 = MathHelper.clamp(f, MathHelper.wrapDegrees(mySeat.getMinYaw() + blockYaw), MathHelper.wrapDegrees(mySeat.getMaxYaw() + blockYaw));
             passenger.prevRotationYaw = f1;
 
             float f2 = MathHelper.wrapDegrees(passenger.rotationPitch);
-            float f3 = MathHelper.clamp(f2, mySeat.getMaxPitch(), mySeat.getMinPitch());
+            float f3 = MathHelper.clamp(f2, mySeat.getMinPitch(), mySeat.getMaxPitch());
             passenger.rotationPitch = f3;
             f2 = MathHelper.wrapDegrees(passenger.prevRotationPitch);
-            f3 = MathHelper.clamp(f2, mySeat.getMaxPitch(), mySeat.getMinPitch());
+            f3 = MathHelper.clamp(f2, mySeat.getMinPitch(), mySeat.getMaxPitch());
             passenger.prevRotationPitch = f3;
         }
     }

--- a/src/main/java/fr/dynamx/common/entities/SeatEntity.java
+++ b/src/main/java/fr/dynamx/common/entities/SeatEntity.java
@@ -48,23 +48,23 @@ public class SeatEntity extends Entity {
      */
     @Override
     public void applyOrientationToEntity(Entity passenger) {
-        if (mySeat != null && mySeat.shouldLimitFieldOfView()) {
-            float blockYaw = block.getPackInfo() == null ? 0 : (block.getPackInfo().getRotation().y - block.getRelativeRotation().y + block.getRotation() * 22.5f);
-
-            float f = MathHelper.wrapDegrees(passenger.rotationYaw);
-            float f1 = MathHelper.clamp(f, MathHelper.wrapDegrees(mySeat.getMinYaw() + blockYaw), MathHelper.wrapDegrees(mySeat.getMaxYaw() + blockYaw));
-            passenger.rotationYaw = f1;
-            f = MathHelper.wrapDegrees(passenger.prevRotationYaw);
-            f1 = MathHelper.clamp(f, MathHelper.wrapDegrees(mySeat.getMinYaw() + blockYaw), MathHelper.wrapDegrees(mySeat.getMaxYaw() + blockYaw));
-            passenger.prevRotationYaw = f1;
-
-            float f2 = MathHelper.wrapDegrees(passenger.rotationPitch);
-            float f3 = MathHelper.clamp(f2, mySeat.getMinPitch(), mySeat.getMaxPitch());
-            passenger.rotationPitch = f3;
-            f2 = MathHelper.wrapDegrees(passenger.prevRotationPitch);
-            f3 = MathHelper.clamp(f2, mySeat.getMinPitch(), mySeat.getMaxPitch());
-            passenger.prevRotationPitch = f3;
+        if (mySeat == null || !mySeat.shouldLimitFieldOfView()) {
+            return;
         }
+        float blockYaw = block.getPackInfo() == null ? 0 : (block.getPackInfo().getRotation().y - block.getRelativeRotation().y + block.getRotation() * 22.5f);
+        passenger.setRenderYawOffset(blockYaw);
+        float f = MathHelper.wrapDegrees(passenger.rotationYaw - blockYaw);
+        float f1 = MathHelper.clamp(f, mySeat.getMinYaw(), mySeat.getMaxYaw());
+        passenger.prevRotationYaw += f1 - f;
+        passenger.rotationYaw += f1 - f;
+        passenger.setRotationYawHead(passenger.rotationYaw);
+
+        float f2 = MathHelper.wrapDegrees(passenger.rotationPitch);
+        float f3 = MathHelper.clamp(f2, mySeat.getMinPitch(), mySeat.getMaxPitch());
+        passenger.rotationPitch = f3;
+        f2 = MathHelper.wrapDegrees(passenger.prevRotationPitch);
+        f3 = MathHelper.clamp(f2, mySeat.getMinPitch(), mySeat.getMaxPitch());
+        passenger.prevRotationPitch = f3;
     }
 
     @Override

--- a/src/main/java/fr/dynamx/common/entities/modules/SeatsModule.java
+++ b/src/main/java/fr/dynamx/common/entities/modules/SeatsModule.java
@@ -126,7 +126,7 @@ public class SeatsModule implements IPhysicsModule<AbstractEntityPhysicsHandler<
      */
     public void applyOrientationToEntity(Entity passenger) {
         passenger.setRenderYawOffset(0);
-        BasePartSeat seat = getRidingSeat(passenger);
+        BasePartSeat<?, ?> seat = getRidingSeat(passenger);
         if (seat != null && seat.shouldLimitFieldOfView()) {
             // Limit yaw
             float f = MathHelper.wrapDegrees(passenger.rotationYaw - entity.rotationYaw);

--- a/src/main/java/fr/dynamx/common/entities/modules/SeatsModule.java
+++ b/src/main/java/fr/dynamx/common/entities/modules/SeatsModule.java
@@ -130,16 +130,16 @@ public class SeatsModule implements IPhysicsModule<AbstractEntityPhysicsHandler<
         if (seat != null && seat.shouldLimitFieldOfView()) {
             // Limit yaw
             float f = MathHelper.wrapDegrees(passenger.rotationYaw - entity.rotationYaw);
-            float f1 = MathHelper.clamp(f, seat.getMaxYaw(), seat.getMinYaw());
+            float f1 = MathHelper.clamp(f, seat.getMinYaw(), seat.getMaxYaw());
             passenger.prevRotationYaw += f1 - f;
             passenger.rotationYaw += f1 - f;
 
             // Limit pitch
             float f2 = MathHelper.wrapDegrees(passenger.rotationPitch);
-            float f3 = MathHelper.clamp(f2, seat.getMaxPitch(), seat.getMinPitch());
+            float f3 = MathHelper.clamp(f2, seat.getMinPitch(), seat.getMaxPitch());
             passenger.rotationPitch = f3;
             f2 = MathHelper.wrapDegrees(passenger.prevRotationPitch);
-            f3 = MathHelper.clamp(f2, seat.getMaxPitch(), seat.getMinPitch());
+            f3 = MathHelper.clamp(f2, seat.getMinPitch(), seat.getMaxPitch());
             passenger.prevRotationPitch = f3;
         }
         passenger.setRotationYawHead(passenger.rotationYaw - entity.rotationYaw);


### PR DESCRIPTION
Fix: The block's rotation wasn't applied to the player/camera rotation when sitting on a block.