### PR TITLE
fix: processPlayer causing crash

### DIFF
--- a/src/main/java/fr/dynamx/common/core/mixin/MixinNetHandlerPlayServer.java
+++ b/src/main/java/fr/dynamx/common/core/mixin/MixinNetHandlerPlayServer.java
@@ -31,24 +31,24 @@ public class MixinNetHandlerPlayServer {
     @Redirect(method = "processPlayer",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;isInvulnerableDimensionChange()Z", ordinal = 0))
     private boolean test(EntityPlayerMP instance) {
-        if (DynamXContext.getWalkingPlayers().containsKey(player)) {
-            //TODO IMPROVE SECURITY
-            //LOGGER.warn("Ignoring moving too quickly from " + player.getName() + " : walking on vehicle !");
+        if (DynamXContext.getWalkingPlayers().containsKey(instance)) {
+            // TODO: IMPROVE SECURITY
+            // LOGGER.warn("Ignoring moving too quickly from " + instance.getName() + " : walking on vehicle !");
             return false;
         } else {
-            return true;
+            return instance.isInvulnerableDimensionChange();
         }
     }
 
     @Redirect(method = "processPlayer",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;isInvulnerableDimensionChange()Z", ordinal = 1))
     private boolean test2(EntityPlayerMP instance) {
-        if (DynamXContext.getWalkingPlayers().containsKey(player)) {
-            //TODO IMPROVE SECURITY
-            //LOGGER.warn("Ignoring moving wrongly from " + player.getName() + " : walking on vehicle !");
+        if (DynamXContext.getWalkingPlayers().containsKey(instance)) {
+            // TODO: IMPROVE SECURITY
+            // LOGGER.warn("Ignoring moving wrongly from " + instance.getName() + " : walking on vehicle !");
             return false;
         } else {
-            return true;
+            return instance.isInvulnerableDimensionChange();
         }
     }
 


### PR DESCRIPTION
I’m not sure if there was a specific reason why the `player` object from above was used in these two methods, but I’ve changed it to use the `instance` that already comes from the method, and the behavior continues to work as expected.

Additionally, I replaced simply returning `true` with a call to `instance.isInvulnerableDimensionChange()`, which resolves a server crash. The crash occurred when sitting in a Decocraft chair and teleporting to a distant location in the same dimension where the chunk gets loaded. Why this happens? No idea. But it’s fixed with this commit.

If anything doesn’t seem right, feel free to reply or reach out to me on Discord.